### PR TITLE
feat: add prefix config option

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,11 +25,12 @@ var OPTIONS = {
 };
 
 
-var GrowlReporter = function(helper, logger) {
+var GrowlReporter = function(helper, logger, config) {
   var log = logger.create('reporter.growl');
 
   var optionsFor = function(type, browser) {
-    return helper.merge(OPTIONS[type], {title: util.format(OPTIONS[type].title, browser)});
+    var prefix = config && config.prefix ? config.prefix : '';
+    return helper.merge(OPTIONS[type], {title: prefix + util.format(OPTIONS[type].title, browser)});
   };
 
   growly.register('Karma', '', [], function(error) {
@@ -60,7 +61,7 @@ var GrowlReporter = function(helper, logger) {
   };
 };
 
-GrowlReporter.$inject = ['helper', 'logger'];
+GrowlReporter.$inject = ['helper', 'logger','config.growlReporter'];
 
 // PUBLISH DI MODULE
 module.exports = {


### PR DESCRIPTION
This patch allows users to prefix the title of growl notifications with a custom string. This is helpful in situations where you have multiple instances of karma running using the auto-watch feature.
## Example Setup

**karma-unit.conf**

``` javascript
module.exports = function(config){
    config.set({
        //all your usual config stuff - files, excludes, etc.
        reporters: ['progress','growl'],
        growlReporter:{
            prefix:'UNIT TESTS-'
        }
   });
};
```

**karma-production.conf**

``` javascript
module.exports = function(config){
    config.set({
        //all your usual config stuff - files, excludes, etc.
        reporters: ['progress','growl'],
        growlReporter:{
            prefix:'PRODUCTION TESTS-'
        }
   });
};
```

![screen shot 2013-08-24 at 2 37 18 pm](https://f.cloud.github.com/assets/4082216/1021228/e59eae5c-0ced-11e3-8e2f-c726911368f5.png)
