### PR TITLE
Added different growl notification types, showing detailed failure messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,18 @@ You can pass list of reporters as a CLI argument too:
 ```bash
 karma start --reporters growl,dots
 ```
+#### Message labels
+The notifications are given different growl labels, which can be used to configure how each are shown
+in the growl client:
+
+* New Success: The test run succeeded for the first time after startup or test failure
+* Success: All other successful test runs
+* Failed: The test run failed
+* Aborted: For some reason the test run did not work
+
+For example, you may make the "Success" and "New Success" green, Failure red, and Aborted orange. Or you may
+wish to hide the Success notifications, so you only see test success notification after they have fixed
+a test failure.
 
 #### Message Prefix (Optional)
 Adds a prefix to the growl message to help differentiate which tests have passed or failed. This is especially usefull if you are running multiple auto-watch instances of karma in parallel.

--- a/index.js
+++ b/index.js
@@ -13,6 +13,12 @@ var OPTIONS = {
     title: 'PASSED - %s',
     icon: path.join(__dirname, 'images/success.png')
   },
+  newSuccess: {
+    dispname: 'New Success',
+    label: "new_success",
+    title: 'PASSED - %s',
+    icon: path.join(__dirname, 'images/success.png')
+  },
   failed: {
     dispname: 'Failure',
     label: 'failure',
@@ -50,21 +56,32 @@ var GrowlReporter = function(helper, logger, config) {
 
   this.adapters = [];
 
+  var lastResultWasSuccess = false;
+
   this.onBrowserComplete = function(browser) {
     var results = browser.lastResult;
     var time = helper.formatTimeInterval(results.totalTime);
 
     if (results.disconnected || results.error) {
+      lastResultWasSuccess = false;
       return growly.notify(MSG_ERROR, optionsFor('error', browser.name));
     }
 
     if (results.failed) {
+      lastResultWasSuccess = false;
       return growly.notify(util.format(MSG_FAILURE, results.failed, results.total, time),
           optionsFor('failed', browser.name));
     }
+    var lastResult = lastResultWasSuccess;
+    lastResultWasSuccess = true;
+    if (lastResult) {
+      return growly.notify(util.format(MSG_SUCCESS, results.success, time), optionsFor('success',
+          browser.name));
+    } else {
+      return growly.notify(util.format(MSG_SUCCESS, results.success, time), optionsFor('newSuccess',
+          browser.name));
+    }
 
-    growly.notify(util.format(MSG_SUCCESS, results.success, time), optionsFor('success',
-        browser.name));
   };
 };
 

--- a/index.js
+++ b/index.js
@@ -9,16 +9,19 @@ var MSG_ERROR = '';
 var OPTIONS = {
   success: {
     dispname: 'Success',
+    label: 'success',
     title: 'PASSED - %s',
     icon: path.join(__dirname, 'images/success.png')
   },
   failed: {
     dispname: 'Failure',
+    label: 'failure',
     title: 'FAILED - %s',
     icon: path.join(__dirname, 'images/failed.png')
   },
   error: {
     dispname: 'Aborted',
+    label: 'aborted',
     title: 'ERROR - %s',
     icon: path.join(__dirname, 'images/error.png')
   }
@@ -33,7 +36,10 @@ var GrowlReporter = function(helper, logger, config) {
     return helper.merge(OPTIONS[type], {title: prefix + util.format(OPTIONS[type].title, browser)});
   };
 
-  growly.register('Karma', '', [], function(error) {
+  var allNotifications = Object.keys(OPTIONS).map(function(key) {
+    return OPTIONS[key];
+  });
+  growly.register('Karma', '', allNotifications, function(error) {
     var warning = 'No running version of GNTP found.\n' +
 	                'Make sure the Growl service is installed and running.\n' +
                   'For more information see https://github.com/theabraham/growly.';


### PR DESCRIPTION
Firstly, the different notification types are given different growl labels, "Success", "New Success", "Failure", "Aborted". These can be used to give each different formatting, or to hide them (e.g. hiding "Success" so only new successes are shown).

Next, basic details about test failures are shown in the notification message text. The test name and error message will be shown.